### PR TITLE
Fix port allocation on hosts without IPv6 loopback

### DIFF
--- a/lite/gym/utils/backend/ports.py
+++ b/lite/gym/utils/backend/ports.py
@@ -50,6 +50,7 @@ the raw exception and should treat it the same way.
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import json
 import logging
@@ -108,19 +109,29 @@ _RECENT_ALLOCATIONS: dict[int, float] = {}
 def _is_port_free(port: int) -> bool:
     """Return *True* if *port* is not bound on any local address.
 
-    Checks IPv4 (0.0.0.0, 127.0.0.1) and IPv6 (::1) WITHOUT SO_REUSEADDR,
-    so that ports held by Docker containers (which bind to both 127.0.0.1
-    and [::1]) are correctly detected as in-use.
+    Checks the IPv4 wildcard and loopback plus the IPv6 loopback and
+    wildcard WITHOUT SO_REUSEADDR, so that ports held by Docker containers
+    (which bind both stacks) are detected as in-use. On hosts where a
+    probed address does not exist (IPv6-disabled hosts are the common
+    case), the bind raises EADDRNOTAVAIL/EAFNOSUPPORT for every port — an
+    address problem, not a port conflict — so those errnos skip the probe
+    instead of marking every port in-use (which would exhaust every band
+    on the host).
     """
     for family, host in [
         (socket.AF_INET, "0.0.0.0"),
         (socket.AF_INET, "127.0.0.1"),
         (socket.AF_INET6, "::1"),
+        (socket.AF_INET6, "::"),
     ]:
         try:
             with socket.socket(family, socket.SOCK_STREAM) as s:
                 s.bind((host, port))
-        except OSError:
+        except OSError as e:
+            # EADDRNOTAVAIL/EAFNOSUPPORT mean the probed address does not
+            # exist on this host, not that the port is taken.
+            if e.errno in (errno.EADDRNOTAVAIL, errno.EAFNOSUPPORT):
+                continue
             return False
     return True
 

--- a/lite/gym/utils/backend/ports.py
+++ b/lite/gym/utils/backend/ports.py
@@ -112,11 +112,11 @@ def _is_port_free(port: int) -> bool:
     Checks the IPv4 wildcard and loopback plus the IPv6 loopback and
     wildcard WITHOUT SO_REUSEADDR, so that ports held by Docker containers
     (which bind both stacks) are detected as in-use. On hosts where a
-    probed address does not exist (IPv6-disabled hosts are the common
-    case), the bind raises EADDRNOTAVAIL/EAFNOSUPPORT for every port — an
-    address problem, not a port conflict — so those errnos skip the probe
-    instead of marking every port in-use (which would exhaust every band
-    on the host).
+    probed address does not exist — no IPv6 stack at all, or no ``::1``
+    on loopback — the probe raises EAFNOSUPPORT/EADDRNOTAVAIL for every
+    port: an address problem, not a port conflict. Those errnos skip the
+    probe instead of marking every port in-use (which would exhaust every
+    band on the host).
     """
     for family, host in [
         (socket.AF_INET, "0.0.0.0"),

--- a/tests/gym/utils/backend/test_ports.py
+++ b/tests/gym/utils/backend/test_ports.py
@@ -1,15 +1,14 @@
 """Bind-probe behavior for lite.gym.utils.backend.ports.
 
 Guards the host-capability edges the probe must survive. On hosts without
-an IPv6 loopback (such hosts are common where IPv6 is disabled at the host
-level) every ``bind(("::1", port))`` raises EADDRNOTAVAIL, which must NOT
-be read as a port conflict — otherwise every port tests in-use and
-``allocate_ports`` can never hand out a port. A missing ``::1`` must not
-blind the probe to a v6-only wildcard holder on ``[::]``, and a non-family
-failure of the ``[::]`` probe must count as in-use. Genuine ::1 and IPv4
-conflicts must always be detected.
+``::1`` on loopback, every ``bind(("::1", port))`` raises EADDRNOTAVAIL,
+which must NOT be read as a port conflict — otherwise every port counts
+as in-use and ``allocate_ports`` can never hand out a port. A missing
+``::1`` must not blind the probe to a v6-only wildcard holder on ``[::]``,
+and a non-family failure of the ``[::]`` probe must count as in-use.
+Genuine ``::1`` and IPv4 conflicts must always be detected.
 
-    uv run pytest tests/gym/utils/backend/test_ports.py
+Run: uv run pytest tests/gym/utils/backend/test_ports.py
 """
 
 from __future__ import annotations
@@ -120,7 +119,7 @@ def test_is_port_free_conservative_on_wildcard_probe_errors(monkeypatch) -> None
     assert ports._is_port_free(port) is False
 
 
-def test_is_port_free_reports_v4_conflict_on_ipv6_absent_host(monkeypatch) -> None:
+def test_is_port_free_reports_v4_conflict_despite_skipped_v6_loopback(monkeypatch) -> None:
     # A real IPv4 listener must still be detected on a host whose ::1 probe
     # is skipped — the skip cannot mask IPv4 occupancy.
     holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/gym/utils/backend/test_ports.py
+++ b/tests/gym/utils/backend/test_ports.py
@@ -1,0 +1,134 @@
+"""Bind-probe behavior for lite.gym.utils.backend.ports.
+
+Guards the host-capability edges the probe must survive. On hosts without
+an IPv6 loopback (such hosts are common where IPv6 is disabled at the host
+level) every ``bind(("::1", port))`` raises EADDRNOTAVAIL, which must NOT
+be read as a port conflict — otherwise every port tests in-use and
+``allocate_ports`` can never hand out a port. A missing ``::1`` must not
+blind the probe to a v6-only wildcard holder on ``[::]``, and a non-family
+failure of the ``[::]`` probe must count as in-use. Genuine ::1 and IPv4
+conflicts must always be detected.
+
+    uv run pytest tests/gym/utils/backend/test_ports.py
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+
+from lite.gym.utils.backend import ports
+
+
+def _free_v4_port() -> int:
+    """A port that is free right now on the IPv4 loopback."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _V6BindFails:
+    """AF_INET6 socket whose binds raise the errno configured per address.
+
+    Addresses missing from *errnos* bind successfully.
+    """
+
+    def __init__(self, errnos: dict[str, int]) -> None:
+        self._errnos = errnos
+
+    def __enter__(self) -> _V6BindFails:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def bind(self, addr: tuple[str, int]) -> None:
+        err = self._errnos.get(addr[0])
+        if err is not None:
+            raise OSError(err, f"bind {addr[0]} unavailable")
+
+    def close(self) -> None:
+        pass
+
+
+def _patch_v6(monkeypatch, v6_socket: _V6BindFails | None, socket_errno: int | None) -> None:
+    """Replace socket.socket: IPv4 sockets stay real; AF_INET6 returns
+    *v6_socket* (bind-time failure) or raises *socket_errno* at creation."""
+    real_socket = socket.socket
+
+    def factory(family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, fileno=None):
+        if family == socket.AF_INET6:
+            if socket_errno is not None:
+                raise OSError(socket_errno, "Address family not supported")
+            return v6_socket
+        return real_socket(family, type, proto, fileno)
+
+    monkeypatch.setattr(ports.socket, "socket", factory)
+
+
+def test_is_port_free_skips_unbindable_ipv6_loopback(monkeypatch) -> None:
+    # Stack present but lo has no ::1: socket() succeeds, ::1 bind raises
+    # EADDRNOTAVAIL for every port, and the [::] wildcard is free. Reading
+    # ::1's failure as "in use" made every band on such a host permanently
+    # exhausted.
+    port = _free_v4_port()
+    _patch_v6(monkeypatch, _V6BindFails({"::1": errno.EADDRNOTAVAIL}), socket_errno=None)
+    assert ports._is_port_free(port) is True
+
+
+def test_is_port_free_skips_absent_ipv6_stack(monkeypatch) -> None:
+    # IPv6 compiled/disabled out entirely: socket(AF_INET6, ...) itself
+    # raises EAFNOSUPPORT — same skip, different failure point.
+    port = _free_v4_port()
+    _patch_v6(monkeypatch, v6_socket=None, socket_errno=errno.EAFNOSUPPORT)
+    assert ports._is_port_free(port) is True
+
+
+def test_is_port_free_still_detects_ipv6_only_holders(monkeypatch) -> None:
+    # The ::1 probe exists to catch containers bound to [::1]; a genuine
+    # conflict (EADDRINUSE) there must still report in-use. The skip is
+    # errno-scoped, not "ignore all IPv6 errors".
+    port = _free_v4_port()
+    _patch_v6(monkeypatch, _V6BindFails({"::1": errno.EADDRINUSE}), socket_errno=None)
+    assert ports._is_port_free(port) is False
+
+
+def test_is_port_free_detects_v6_wildcard_holder_without_loopback(monkeypatch) -> None:
+    # A missing ::1 does not prove IPv6 is unusable: a v6-only listener on
+    # [::] is invisible to the IPv4 probes and to the ::1 probe (which
+    # cannot run here at all). The [::] probe must still report the port
+    # busy.
+    port = _free_v4_port()
+    _patch_v6(
+        monkeypatch,
+        _V6BindFails({"::1": errno.EADDRNOTAVAIL, "::": errno.EADDRINUSE}),
+        socket_errno=None,
+    )
+    assert ports._is_port_free(port) is False
+
+
+def test_is_port_free_conservative_on_wildcard_probe_errors(monkeypatch) -> None:
+    # A wildcard-probe failure that is neither a real holder (EADDRINUSE)
+    # nor family-level unavailability (fd exhaustion, kernel memory, ...)
+    # leaves the port unverified — report in-use instead of allocating it.
+    port = _free_v4_port()
+    _patch_v6(
+        monkeypatch,
+        _V6BindFails({"::1": errno.EADDRNOTAVAIL, "::": errno.EMFILE}),
+        socket_errno=None,
+    )
+    assert ports._is_port_free(port) is False
+
+
+def test_is_port_free_reports_v4_conflict_on_ipv6_absent_host(monkeypatch) -> None:
+    # A real IPv4 listener must still be detected on a host whose ::1 probe
+    # is skipped — the skip cannot mask IPv4 occupancy.
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("0.0.0.0", 0))
+    holder.listen(1)
+    try:
+        port = int(holder.getsockname()[1])
+        _patch_v6(monkeypatch, _V6BindFails({"::1": errno.EADDRNOTAVAIL}), socket_errno=None)
+        assert ports._is_port_free(port) is False
+    finally:
+        holder.close()


### PR DESCRIPTION
## Problem

On hosts whose loopback has no IPv6 `::1` address — no IPv6 stack at all, or a present stack without `::1` on `lo` — no Docker-backed env can start:

- `serve_env.py --warm-singleton` never brings up the warm container.
- Every `POST /instances/<id>/reset` returns `503` with a `Retry-After` hint, and the client eventually fails the task with `lite.gym.errors.CapacityExhausted`.

## Root cause

`_is_port_free()` bind-probes `0.0.0.0`, `127.0.0.1`, and `::1` so that ports held by Docker containers (which bind both loopbacks) are detected as in-use. On a host with no `::1`, `bind(("::1", port))` raises `EADDRNOTAVAIL` — or `socket(AF_INET6, ...)` itself raises `EAFNOSUPPORT` — for **every** port. The probe read that as "port in use", so every port in every band looked occupied and `allocate_ports()` raised `CapacityExhausted` on the very first allocation.

## Fix

Treat `EADDRNOTAVAIL`/`EAFNOSUPPORT` as "this address does not exist on the host" rather than "port in use": the probe is skipped instead of failing. An unavailable address is not a port conflict — nothing on the host can hold it.

The probe list also gains the `[::]` wildcard (next to `::1`), so a v6-only listener holding only the IPv6 wildcard is still detected when `::1` itself cannot be probed.

## Evidence (Linux host with no `::1` on loopback, env-server split mode)

The affected host has an IPv6 stack but no `::1` on loopback, so every `::1` bind fails while the `[::]` wildcard is bindable:

```
bind(("::1", p)) -> EADDRNOTAVAIL   # every port: address missing, not a conflict
bind(("::", p))   -> OK
```

So the `[::]` wildcard probe is active on this host class: a v6-only listener holding `[::]` is still detected even though `::1` cannot be probed.

Allocator, before the fix — every band exhausted:

```
(7660, 7700) -> CapacityExhausted : port range [7660, 7700) exhausted: found only 0/1 free (retry_after_s=30)
(9554, 9700) -> CapacityExhausted : port range [9554, 9700) exhausted: found only 0/1 free (retry_after_s=30)
```

Full stack, before the fix — the first task's `reset` loops on 503 until the client deadline:

```
POST /instances/<id>/reset "HTTP/1.1 503 Service Unavailable"
/reset 503 on inst <id>; retry 1 after 30.0s (server hint, 297s deadline remaining)
...
lite.gym.errors.CapacityExhausted: port range [9554, 9700) exhausted: found only 0/1 free (retry_after_s=30)
```

Allocator, after the fix (same host):

```
(7660, 7700) -> [7693]
(9554, 9700) -> [9681]
```

Full stack, after the fix — the env-server boots (`Allocated ports: [7696]`, warm singleton ready) and an AndroidWorld episode runs end-to-end: `POST /instances` 201, `reset` 200 on the first attempt, agent turns executed against the live container, clean exit.

## Tests

`tests/gym/utils/backend/test_ports.py` — 6 regression tests:

- `::1` bind failing with `EADDRNOTAVAIL`, `[::]` wildcard free → port reported free (the bug: read as in-use).
- `socket(AF_INET6)` construction raising `EAFNOSUPPORT` → port still reported free.
- `::1` bind failing with `EADDRINUSE` → still detected as in-use (the skip is errno-scoped; Docker dual-stack detection is preserved).
- `::1` → `EADDRNOTAVAIL` while a v6-only listener holds `[::]` → still detected as in-use.
- `::1` → `EADDRNOTAVAIL` and the wildcard probe failing with a non-family error (`EMFILE`) → still reported in-use (unverified means in-use, like every other probe).
- A live IPv4 listener is still detected as in-use on a host whose `::1` probe is skipped.

Full backend suite on the branch: 710 passed, 1 skipped (pre-existing unrelated captcha-deps skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
